### PR TITLE
Attempt to fix application crashes on index async

### DIFF
--- a/src/log4stash/ElasticClient/ElasticClient.cs
+++ b/src/log4stash/ElasticClient/ElasticClient.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using log4net.Util;
 using log4stash.JsonConverters;
 using Newtonsoft.Json;
 
@@ -109,10 +110,17 @@ namespace log4stash
 
         private void FinishGetResponse(IAsyncResult result)
         {
-            var webRequest = (WebRequest)result.AsyncState;
-            using (var httpResponse = (HttpWebResponse)webRequest.EndGetResponse(result))
+            try
             {
-                CheckResponse(httpResponse);
+                var webRequest = (WebRequest)result.AsyncState;
+                using (var httpResponse = (HttpWebResponse)webRequest.EndGetResponse(result))
+                {
+                    CheckResponse(httpResponse);
+                }
+            }
+            catch (Exception ex)
+            {
+                LogLog.Error(GetType(), "Invalid request to ElasticSearch", ex);
             }
         }
 

--- a/src/log4stash/ElasticSearchAppender.cs
+++ b/src/log4stash/ElasticSearchAppender.cs
@@ -177,6 +177,7 @@ namespace log4stash
                 }
                 catch (Exception ex)
                 {
+                    //async exceptions will never get here
                     LogLog.Error(GetType(), "Invalid connection to ElasticSearch", ex);
                 }
             }


### PR DESCRIPTION
The application crashes sometimes when the elastic server could not be reached and the httpclient throws an exception that is not handled in code since the request is called asynchronously.
