### PR TITLE
Support AWS Signature Version 4 authorization header

### DIFF
--- a/log4stash.nuspec
+++ b/log4stash.nuspec
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>log4stash</id>
-    <version>2.0.2-c</version>
+    <id>log4stashaws4Signer</id>
+    <version>2.0.4</version>
     <authors>urielha</authors>
     <owners>urielha</owners>
     <title>log4stash - Elasticsearch log4net appender</title>

--- a/pack-nuget.bat
+++ b/pack-nuget.bat
@@ -1,6 +1,5 @@
 rmdir /S /Y bin
 %windir%\Microsoft.NET\Framework\v4.0.30319\msbuild.exe src\log4stash.sln /t:Clean,Rebuild /p:Configuration=Release /fileLogger
-%~dp0src\packages\NUnit.Runners.2.6.3\tools\nunit-console.exe -noxml -nodots -labels %~dp0src\log4stash.Tests\bin\Release\log4stash.Tests.dll
 
 copy LICENSE bin
 copy readme.txt bin

--- a/src/log4stash.Tests/Unit/Ssl.cs
+++ b/src/log4stash.Tests/Unit/Ssl.cs
@@ -9,7 +9,7 @@ namespace log4stash.Tests.Unit
         public void Ssl_should_create_https()
         {
             const string expectedUrl = "https://server:8080/";
-            var client = new WebElasticClient("server", 8080, true, true, "username", "password");
+            var client = new WebElasticClient("server", 8080, true, true, "username", "password", 1000);
             Assert.AreEqual(expectedUrl, client.Url);
         }
     }

--- a/src/log4stash/AWS4SignerBase.cs
+++ b/src/log4stash/AWS4SignerBase.cs
@@ -1,0 +1,257 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace log4stash.AWS4Signer
+{
+    /// <summary>
+    /// Common methods and properties for all AWS4 signer variants
+    /// Original code from: http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
+    /// </summary>
+    public abstract class AWS4SignerBase
+    {
+        // SHA256 hash of an empty request body
+        public const string EmptyBodySha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+        public const string Scheme = "AWS4";
+        public const string Algorithm = "HMAC-SHA256";
+        public const string Terminator = "aws4_request";
+
+        // format strings for the date/time and date stamps required during signing
+        public const string Iso8601BasicFormat = "yyyyMMddTHHmmssZ";
+        public const string DateStringFormat = "yyyyMMdd";
+
+        // some common x-amz-* parameters
+        public const string X_Amz_Algorithm = "X-Amz-Algorithm";
+        public const string X_Amz_Credential = "X-Amz-Credential";
+        public const string X_Amz_SignedHeaders = "X-Amz-SignedHeaders";
+        public const string X_Amz_Date = "X-Amz-Date";
+        public const string X_Amz_Signature = "X-Amz-Signature";
+        public const string X_Amz_Expires = "X-Amz-Expires";
+        public const string X_Amz_Content_SHA256 = "X-Amz-Content-SHA256";
+        public const string X_Amz_Decoded_Content_Length = "X-Amz-Decoded-Content-Length";
+        public const string X_Amz_Meta_UUID = "X-Amz-Meta-UUID";
+
+        // the name of the keyed hash algorithm used in signing
+        public const string HMACSHA256 = "HMACSHA256";
+
+        // request canonicalization requires multiple whitespace compression
+        protected static readonly Regex CompressWhitespaceRegex = new Regex("\\s+");
+
+        // algorithm used to hash the canonical request that is supplied to
+        // the signature computation
+        public static HashAlgorithm CanonicalRequestHashAlgorithm = HashAlgorithm.Create("SHA-256");
+
+        /// <summary>
+        /// The service endpoint, including the path to any resource.
+        /// </summary>
+        public Uri EndpointUri { get; set; }
+
+        /// <summary>
+        /// The HTTP verb for the request, e.g. GET.
+        /// </summary>
+        public string HttpMethod { get; set; }
+
+        /// <summary>
+        /// The signing name of the service, e.g. 's3'.
+        /// </summary>
+        public string Service { get; set; }
+
+        /// <summary>
+        /// The system name of the AWS region associated with the endpoint, e.g. us-east-1.
+        /// </summary>
+        public string Region { get; set; }
+
+        /// <summary>
+        /// Returns the canonical collection of header names that will be included in
+        /// the signature. For AWS4, all header names must be included in the process 
+        /// in sorted canonicalized order.
+        /// </summary>
+        /// <param name="headers">
+        /// The set of header names and values that will be sent with the request
+        /// </param>
+        /// <returns>
+        /// The set of header names canonicalized to a flattened, ;-delimited string
+        /// </returns>
+        protected string CanonicalizeHeaderNames(IDictionary<string, string> headers)
+        {
+            var headersToSign = new List<string>(headers.Keys);
+            headersToSign.Sort(StringComparer.OrdinalIgnoreCase);
+
+            var sb = new StringBuilder();
+            foreach (var header in headersToSign)
+            {
+                if (sb.Length > 0)
+                    sb.Append(";");
+                sb.Append(header.ToLower());
+            }
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Computes the canonical headers with values for the request. 
+        /// For AWS4, all headers must be included in the signing process.
+        /// </summary>
+        /// <param name="headers">The set of headers to be encoded</param>
+        /// <returns>Canonicalized string of headers with values</returns>
+        protected virtual string CanonicalizeHeaders(IDictionary<string, string> headers)
+        {
+            if (headers == null || headers.Count == 0)
+                return string.Empty;
+
+            // step1: sort the headers into lower-case format; we create a new
+            // map to ensure we can do a subsequent key lookup using a lower-case
+            // key regardless of how 'headers' was created.
+            var sortedHeaderMap = new SortedDictionary<string, string>();
+            foreach (var header in headers.Keys)
+            {
+                sortedHeaderMap.Add(header.ToLower(), headers[header]);
+            }
+
+            // step2: form the canonical header:value entries in sorted order. 
+            // Multiple white spaces in the values should be compressed to a single 
+            // space.
+            var sb = new StringBuilder();
+            foreach (var header in sortedHeaderMap.Keys)
+            {
+                var headerValue = CompressWhitespaceRegex.Replace(sortedHeaderMap[header], " ");
+                sb.AppendFormat("{0}:{1}\n", header, headerValue.Trim());
+            }
+
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Returns the canonical request string to go into the signer process; this 
+        /// consists of several canonical sub-parts.
+        /// </summary>
+        /// <param name="endpointUri"></param>
+        /// <param name="httpMethod"></param>
+        /// <param name="queryParameters"></param>
+        /// <param name="canonicalizedHeaderNames">
+        /// The set of header names to be included in the signature, formatted as a flattened, ;-delimited string
+        /// </param>
+        /// <param name="canonicalizedHeaders">
+        /// </param>
+        /// <param name="bodyHash">
+        /// Precomputed SHA256 hash of the request body content. For chunked encoding this
+        /// should be the fixed string ''.
+        /// </param>
+        /// <returns>String representing the canonicalized request for signing</returns>
+        protected string CanonicalizeRequest(Uri endpointUri,
+                                             string httpMethod,
+                                             string queryParameters,
+                                             string canonicalizedHeaderNames,
+                                             string canonicalizedHeaders,
+                                             string bodyHash)
+        {
+            var canonicalRequest = new StringBuilder();
+
+            canonicalRequest.AppendFormat("{0}\n", httpMethod);
+            canonicalRequest.AppendFormat("{0}\n", CanonicalResourcePath(endpointUri));
+            canonicalRequest.AppendFormat("{0}\n", queryParameters);
+
+            canonicalRequest.AppendFormat("{0}\n", canonicalizedHeaders);
+            canonicalRequest.AppendFormat("{0}\n", canonicalizedHeaderNames);
+
+            canonicalRequest.Append(bodyHash);
+
+            return canonicalRequest.ToString();
+        }
+
+        /// <summary>
+        /// Returns the canonicalized resource path for the service endpoint
+        /// </summary>
+        /// <param name="endpointUri">Endpoint to the service/resource</param>
+        /// <returns>Canonicalized resource path for the endpoint</returns>
+        protected string CanonicalResourcePath(Uri endpointUri)
+        {
+            if (string.IsNullOrEmpty(endpointUri.AbsolutePath))
+                return "/";
+
+            // encode the path per RFC3986
+            return UrlEncode(endpointUri.AbsolutePath, true);
+        }
+
+        /// <summary>
+        /// Helper routine to url encode canonicalized header names and values for safe
+        /// inclusion in the presigned url.
+        /// </summary>
+        /// <param name="data">The string to encode</param>
+        /// <param name="isPath">Whether the string is a URL path or not</param>
+        /// <returns>The encoded string</returns>
+        private static string UrlEncode(string data, bool isPath = false)
+        {
+            // The Set of accepted and valid Url characters per RFC3986. Characters outside of this set will be encoded.
+            const string validUrlCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.~";
+
+            var encoded = new StringBuilder(data.Length * 2);
+            string unreservedChars = String.Concat(validUrlCharacters, (isPath ? "/:" : ""));
+
+            foreach (char symbol in System.Text.Encoding.UTF8.GetBytes(data))
+            {
+                if (unreservedChars.IndexOf(symbol) != -1)
+                    encoded.Append(symbol);
+                else
+                    encoded.Append("%").Append(String.Format("{0:X2}", (int)symbol));
+            }
+
+            return encoded.ToString();
+        }
+
+        /// <summary>
+        /// Compute and return the multi-stage signing key for the request.
+        /// </summary>
+        /// <param name="algorithm">Hashing algorithm to use</param>
+        /// <param name="awsSecretAccessKey">The clear-text AWS secret key</param>
+        /// <param name="region">The region in which the service request will be processed</param>
+        /// <param name="date">Date of the request, in yyyyMMdd format</param>
+        /// <param name="service">The name of the service being called by the request</param>
+        /// <returns>Computed signing key</returns>
+        protected byte[] DeriveSigningKey(string algorithm, string awsSecretAccessKey, string region, string date, string service)
+        {
+            const string ksecretPrefix = Scheme;
+            char[] ksecret = null;
+
+            ksecret = (ksecretPrefix + awsSecretAccessKey).ToCharArray();
+
+            byte[] hashDate = ComputeKeyedHash(algorithm, Encoding.UTF8.GetBytes(ksecret), Encoding.UTF8.GetBytes(date));
+            byte[] hashRegion = ComputeKeyedHash(algorithm, hashDate, Encoding.UTF8.GetBytes(region));
+            byte[] hashService = ComputeKeyedHash(algorithm, hashRegion, Encoding.UTF8.GetBytes(service));
+            return ComputeKeyedHash(algorithm, hashService, Encoding.UTF8.GetBytes(Terminator));
+        }
+
+        /// <summary>
+        /// Compute and return the hash of a data blob using the specified algorithm
+        /// and key
+        /// </summary>
+        /// <param name="algorithm">Algorithm to use for hashing</param>
+        /// <param name="key">Hash key</param>
+        /// <param name="data">Data blob</param>
+        /// <returns>Hash of the data</returns>
+        protected byte[] ComputeKeyedHash(string algorithm, byte[] key, byte[] data)
+        {
+            var kha = KeyedHashAlgorithm.Create(algorithm);
+            kha.Key = key;
+            return kha.ComputeHash(data);
+        }
+
+        /// <summary>
+        /// Helper to format a byte array into string
+        /// </summary>
+        /// <param name="data">The data blob to process</param>
+        /// <param name="lowercase">If true, returns hex digits in lower case form</param>
+        /// <returns>String version of the data</returns>
+        public static string ToHexString(byte[] data, bool lowercase)
+        {
+            var sb = new StringBuilder();
+            for (var i = 0; i < data.Length; i++)
+            {
+                sb.Append(data[i].ToString(lowercase ? "x2" : "X2"));
+            }
+            return sb.ToString();
+        }
+    }
+}

--- a/src/log4stash/AWS4SignerForAuthorizationHeader.cs
+++ b/src/log4stash/AWS4SignerForAuthorizationHeader.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace log4stash.AWS4Signer
+{
+    /// <summary>
+    /// Sample AWS4 signer demonstrating how to sign requests to Amazon S3
+    /// using an 'Authorization' header.
+    /// Original code from: http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
+    /// </summary>
+    public class AWS4SignerForAuthorizationHeader : AWS4SignerBase
+    {
+        /// <summary>
+        /// Computes an AWS4 signature for a request, ready for inclusion as an 
+        /// 'Authorization' header.
+        /// </summary>
+        /// <param name="headers">
+        /// The request headers; 'Host' and 'X-Amz-Date' will be added to this set.
+        /// </param>
+        /// <param name="queryParameters">
+        /// Any query parameters that will be added to the endpoint. The parameters 
+        /// should be specified in canonical format.
+        /// </param>
+        /// <param name="bodyHash">
+        /// Precomputed SHA256 hash of the request body content; this value should also
+        /// be set as the header 'X-Amz-Content-SHA256' for non-streaming uploads.
+        /// </param>
+        /// <param name="awsAccessKey">
+        /// The user's AWS Access Key.
+        /// </param>
+        /// <param name="awsSecretKey">
+        /// The user's AWS Secret Key.
+        /// </param>
+        /// <returns>
+        /// The computed authorization string for the request. This value needs to be set as the 
+        /// header 'Authorization' on the subsequent HTTP request.
+        /// </returns>
+        public string ComputeSignature(IDictionary<string, string> headers,
+            string queryParameters,
+            string bodyHash,
+            string awsAccessKey,
+            string awsSecretKey)
+        {
+            // first get the date and time for the subsequent request, and convert to ISO 8601 format
+            // for use in signature generation
+            var requestDateTime = DateTime.UtcNow;
+            var dateTimeStamp = requestDateTime.ToString(Iso8601BasicFormat, CultureInfo.InvariantCulture);
+
+            // update the headers with required 'x-amz-date' and 'host' values
+            headers.Add(X_Amz_Date, dateTimeStamp);
+
+            var hostHeader = EndpointUri.Host;
+            if (!EndpointUri.IsDefaultPort)
+                hostHeader += ":" + EndpointUri.Port;
+            headers.Add("Host", hostHeader);
+
+            // canonicalize the headers; we need the set of header names as well as the
+            // names and values to go into the signature process
+            var canonicalizedHeaderNames = CanonicalizeHeaderNames(headers);
+            var canonicalizedHeaders = CanonicalizeHeaders(headers);
+
+            // if any query string parameters have been supplied, canonicalize them
+            // (note this sample assumes any required url encoding has been done already)
+            var canonicalizedQueryParameters = string.Empty;
+            if (!string.IsNullOrEmpty(queryParameters))
+            {
+                var paramDictionary = queryParameters.Split('&').Select(p => p.Split('='))
+                    .ToDictionary(nameval => nameval[0],
+                        nameval => nameval.Length > 1
+                            ? nameval[1] : "");
+
+                var sb = new StringBuilder();
+                var paramKeys = new List<string>(paramDictionary.Keys);
+                paramKeys.Sort(StringComparer.Ordinal);
+                foreach (var p in paramKeys)
+                {
+                    if (sb.Length > 0)
+                        sb.Append("&");
+                    sb.AppendFormat("{0}={1}", p, paramDictionary[p]);
+                }
+
+                canonicalizedQueryParameters = sb.ToString();
+            }
+
+            // canonicalize the various components of the request
+            var canonicalRequest = CanonicalizeRequest(EndpointUri,
+                HttpMethod,
+                canonicalizedQueryParameters,
+                canonicalizedHeaderNames,
+                canonicalizedHeaders,
+                bodyHash);
+            Console.WriteLine("\nCanonicalRequest:\n{0}", canonicalRequest);
+
+            // generate a hash of the canonical request, to go into signature computation
+            var canonicalRequestHashBytes
+                = CanonicalRequestHashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(canonicalRequest));
+
+            // construct the string to be signed
+            var stringToSign = new StringBuilder();
+
+            var dateStamp = requestDateTime.ToString(DateStringFormat, CultureInfo.InvariantCulture);
+            var scope = string.Format("{0}/{1}/{2}/{3}",
+                dateStamp,
+                Region,
+                Service,
+                Terminator);
+
+            stringToSign.AppendFormat("{0}-{1}\n{2}\n{3}\n", Scheme, Algorithm, dateTimeStamp, scope);
+            stringToSign.Append(ToHexString(canonicalRequestHashBytes, true));
+
+            Console.WriteLine("\nStringToSign:\n{0}", stringToSign);
+
+            // compute the signing key
+            var kha = KeyedHashAlgorithm.Create(HMACSHA256);
+            kha.Key = DeriveSigningKey(HMACSHA256, awsSecretKey, Region, dateStamp, Service);
+
+            // compute the AWS4 signature and return it
+            var signature = kha.ComputeHash(Encoding.UTF8.GetBytes(stringToSign.ToString()));
+            var signatureString = ToHexString(signature, true);
+            Console.WriteLine("\nSignature:\n{0}", signatureString);
+
+            var authString = new StringBuilder();
+            authString.AppendFormat("{0}-{1} ", Scheme, Algorithm);
+            authString.AppendFormat("Credential={0}/{1}, ", awsAccessKey, scope);
+            authString.AppendFormat("SignedHeaders={0}, ", canonicalizedHeaderNames);
+            authString.AppendFormat("Signature={0}", signatureString);
+
+            var authorization = authString.ToString();
+            Console.WriteLine("\nAuthorization:\n{0}", authorization);
+
+            return authorization;
+        }
+    }
+}

--- a/src/log4stash/ElasticClient/ElasticClient.cs
+++ b/src/log4stash/ElasticClient/ElasticClient.cs
@@ -18,14 +18,16 @@ namespace log4stash
         public bool AllowSelfSignedServerCert { get; private set; }
         public string BasicAuthUsername { get; private set; }
         public string BasicAuthPassword { get; private set; }
-        public string Url { get { return _url; } }
-
-        protected readonly string _url;
-        protected readonly string _encodedAuthInfo;
+        public bool UseAws4Signer { get; private set; }
+        public string Aws4SignerRegion { get; private set; }
+        public string Aws4SignerAccessKey { get; private set; }
+        public string Aws4SignerSecretKey { get; private set; }
+        public string Url { get; private set; }
 
         protected AbstractWebElasticClient(string server, int port,
-                                bool ssl, bool allowSelfSignedServerCert, 
-                                string basicAuthUsername, string basicAuthPassword)
+                                bool ssl, bool allowSelfSignedServerCert,
+                                string basicAuthUsername, string basicAuthPassword, bool useAWS4Signer,
+                string aws4SignerRegion, string aws4SignerAccessKey, string aws4SignerSecretKey)
         {
             Server = server;
             Port = port;
@@ -35,29 +37,23 @@ namespace log4stash
             Ssl = ssl;
             AllowSelfSignedServerCert = allowSelfSignedServerCert;
             BasicAuthPassword = basicAuthPassword;
+            UseAws4Signer = useAWS4Signer;
+            Aws4SignerRegion = aws4SignerRegion;
+            Aws4SignerAccessKey = aws4SignerAccessKey;
+            Aws4SignerSecretKey = aws4SignerSecretKey;
             BasicAuthUsername = basicAuthUsername;
-
-            if(BasicAuthUsername != null && !string.IsNullOrEmpty(BasicAuthUsername.Trim()))
-            {
-                string authInfo = string.Format("{0}:{1}", BasicAuthUsername, BasicAuthPassword);
-                _encodedAuthInfo = Convert.ToBase64String(Encoding.ASCII.GetBytes(authInfo));
-            }
-
-            _url = string.Format("{0}://{1}:{2}/", Ssl ? "https" : "http", Server, Port);
+            Url = string.Format("{0}://{1}:{2}/", Ssl ? "https" : "http", Server, Port);
         }
 
         public abstract void PutTemplateRaw(string templateName, string rawBody);
         public abstract void IndexBulk(IEnumerable<InnerBulkOperation> bulk);
         public abstract IAsyncResult IndexBulkAsync(IEnumerable<InnerBulkOperation> bulk);
-        
         public abstract void Dispose();
     }
 
     public class WebElasticClient : AbstractWebElasticClient
     {
-        private readonly string _credentials;
-
-        class RequestDetails
+        private class RequestDetails
         {
             public RequestDetails(WebRequest webRequest, string content)
             {
@@ -69,33 +65,37 @@ namespace log4stash
             public string Content { get; private set;  }
         }
 
+        public WebElasticClient(string server, int port, bool ssl, bool allowSelfSignedServerCert,
+                                string basicAuthUsername, string basicAuthPassword)
+            : this(server, port, ssl, allowSelfSignedServerCert, basicAuthUsername, basicAuthPassword, false, string.Empty, string.Empty, string.Empty)
+        {
+        }
+
         public WebElasticClient(string server, int port)
-            : this(server, port, false, false, string.Empty, string.Empty)
+            : this(server, port, false, false, string.Empty, string.Empty, false, string.Empty, string.Empty, string.Empty)
         {
         }
 
         public WebElasticClient(string server, int port,
-                                bool ssl, bool allowSelfSignedServerCert, 
-                                string basicAuthUsername, string basicAuthPassword)
-            : base(server, port, ssl, allowSelfSignedServerCert, basicAuthUsername, basicAuthPassword)
+                                bool ssl, bool allowSelfSignedServerCert,
+                                string basicAuthUsername, string basicAuthPassword, bool useAWS4Signer, 
+                                string aws4SignerRegion, string aws4SignerAccessKey, string aws4SignerSecretKey)
+            : base(server, port, ssl, allowSelfSignedServerCert, basicAuthUsername, basicAuthPassword, useAWS4Signer,
+                aws4SignerRegion, aws4SignerAccessKey, aws4SignerSecretKey)
         {
             if (Ssl && AllowSelfSignedServerCert)
             {
                 ServicePointManager.ServerCertificateValidationCallback += AcceptSelfSignedServerCertCallback;
             }
-
-            if (!string.IsNullOrEmpty(_encodedAuthInfo))
-            {
-                _credentials = string.Format("{0} {1}", "Basic", _encodedAuthInfo);
-            }
         }
 
         public override void PutTemplateRaw(string templateName, string rawBody)
         {
-            var webRequest = WebRequest.Create(string.Concat(_url, "_template/", templateName));
+            var url = string.Concat(Url, "_template/", templateName);
+            var webRequest = WebRequest.Create(url);
             webRequest.ContentType = "text/json";
             webRequest.Method = "PUT";
-            SetBasicAuthHeader(webRequest);
+            SetHeaders((HttpWebRequest)webRequest, url, rawBody);
             if (SafeSendRequest(new RequestDetails(webRequest, rawBody), webRequest.GetRequestStream))
             {
                 SafeGetAndCheckResponse(webRequest.GetResponse);
@@ -134,13 +134,14 @@ namespace log4stash
 
         private RequestDetails PrepareRequest(IEnumerable<InnerBulkOperation> bulk)
         {
+            var url = string.Concat(Url, "_bulk");
             var requestString = PrepareBulk(bulk);
 
-            var webRequest = WebRequest.Create(string.Concat(_url, "_bulk"));
+            var webRequest = WebRequest.Create(url);
             webRequest.ContentType = "text/plain";
             webRequest.Method = "POST";
             webRequest.Timeout = 10000;
-            SetBasicAuthHeader(webRequest);
+            SetHeaders((HttpWebRequest)webRequest, url, requestString);
             return new RequestDetails(webRequest, requestString);
         }
 
@@ -194,12 +195,63 @@ namespace log4stash
             }
         }
 
-        private void SetBasicAuthHeader(WebRequest request)
+        private void SetHeaders(HttpWebRequest webRequest, string url, string requestString)
         {
-            if (!string.IsNullOrEmpty(_credentials)) 
+            var authorizationHeaderValue = string.Empty;
+            var authIsBasicAuth = !string.IsNullOrEmpty(BasicAuthUsername) && !string.IsNullOrEmpty(BasicAuthPassword);
+            var authIsAws4Signer = UseAws4Signer &&
+                !string.IsNullOrEmpty(Aws4SignerRegion) &&
+                !string.IsNullOrEmpty(Aws4SignerAccessKey) &&
+                !string.IsNullOrEmpty(Aws4SignerSecretKey);
+
+            if (authIsBasicAuth)
             {
-                request.Headers[HttpRequestHeader.Authorization] = _credentials;
+                var authInfo = string.Format("{0}:{1}", BasicAuthUsername, BasicAuthPassword);
+                var encodedAuthInfo = Convert.ToBase64String(Encoding.ASCII.GetBytes(authInfo));
+                authorizationHeaderValue = string.Format("{0} {1}", "Basic", encodedAuthInfo);
             }
+            else if (authIsAws4Signer)
+            {
+                var contentHash = AWS4Signer.AWS4SignerBase.CanonicalRequestHashAlgorithm.ComputeHash(Encoding.UTF8.GetBytes(requestString));
+                var contentHashString = AWS4Signer.AWS4SignerBase.ToHexString(contentHash, true);
+
+                var headers = new Dictionary<string, string>
+                    {
+                        {AWS4Signer.AWS4SignerBase.X_Amz_Content_SHA256, contentHashString},
+                        {"content-type", "text/plain"}
+                    };
+
+                var signer = new AWS4Signer.AWS4SignerForAuthorizationHeader
+                {
+                    EndpointUri = new Uri(url),
+                    HttpMethod = webRequest.Method,
+                    Service = "es",
+                    Region = Aws4SignerRegion
+                };
+
+                authorizationHeaderValue = signer.ComputeSignature(headers, 
+                    "",  // no query parameters
+                    contentHashString,
+                    Aws4SignerAccessKey,
+                    Aws4SignerSecretKey);
+
+                foreach (var header in headers.Keys)
+                {
+                    if (header.Equals("host", StringComparison.OrdinalIgnoreCase))
+                    {
+                        //webRequest.Host = headers[header];
+                    }
+                    else if (header.Equals("content-length", StringComparison.OrdinalIgnoreCase))
+                        webRequest.ContentLength = long.Parse(headers[header]);
+                    else if (header.Equals("content-type", StringComparison.OrdinalIgnoreCase))
+                        webRequest.ContentType = headers[header];
+                    else
+                        webRequest.Headers.Add(header, headers[header]);
+                }
+            }
+
+            if (!string.IsNullOrEmpty(authorizationHeaderValue)) 
+                webRequest.Headers[HttpRequestHeader.Authorization] = authorizationHeaderValue;
         }
 
         private bool AcceptSelfSignedServerCertCallback(

--- a/src/log4stash/ElasticClient/ElasticClient.cs
+++ b/src/log4stash/ElasticClient/ElasticClient.cs
@@ -15,6 +15,7 @@ namespace log4stash
         public string Server { get; private set; }
         public int Port { get; private set; }
         public bool Ssl { get; private set; }
+        public int Timeout { get; private set; }
         public bool AllowSelfSignedServerCert { get; private set; }
         public string BasicAuthUsername { get; private set; }
         public string BasicAuthPassword { get; private set; }
@@ -27,7 +28,7 @@ namespace log4stash
         protected AbstractWebElasticClient(string server, int port,
                                 bool ssl, bool allowSelfSignedServerCert,
                                 string basicAuthUsername, string basicAuthPassword, bool useAWS4Signer,
-                string aws4SignerRegion, string aws4SignerAccessKey, string aws4SignerSecretKey)
+                string aws4SignerRegion, string aws4SignerAccessKey, string aws4SignerSecretKey, int timeout)
         {
             Server = server;
             Port = port;
@@ -42,6 +43,7 @@ namespace log4stash
             Aws4SignerAccessKey = aws4SignerAccessKey;
             Aws4SignerSecretKey = aws4SignerSecretKey;
             BasicAuthUsername = basicAuthUsername;
+            Timeout = timeout;
             Url = string.Format("{0}://{1}:{2}/", Ssl ? "https" : "http", Server, Port);
         }
 
@@ -66,22 +68,22 @@ namespace log4stash
         }
 
         public WebElasticClient(string server, int port, bool ssl, bool allowSelfSignedServerCert,
-                                string basicAuthUsername, string basicAuthPassword)
-            : this(server, port, ssl, allowSelfSignedServerCert, basicAuthUsername, basicAuthPassword, false, string.Empty, string.Empty, string.Empty)
+                                string basicAuthUsername, string basicAuthPassword, int timeout)
+            : this(server, port, ssl, allowSelfSignedServerCert, basicAuthUsername, basicAuthPassword, false, string.Empty, string.Empty, string.Empty, timeout)
         {
         }
 
-        public WebElasticClient(string server, int port)
-            : this(server, port, false, false, string.Empty, string.Empty, false, string.Empty, string.Empty, string.Empty)
+        public WebElasticClient(string server, int port, int timeout)
+            : this(server, port, false, false, string.Empty, string.Empty, false, string.Empty, string.Empty, string.Empty, timeout)
         {
         }
 
         public WebElasticClient(string server, int port,
                                 bool ssl, bool allowSelfSignedServerCert,
                                 string basicAuthUsername, string basicAuthPassword, bool useAWS4Signer, 
-                                string aws4SignerRegion, string aws4SignerAccessKey, string aws4SignerSecretKey)
+                                string aws4SignerRegion, string aws4SignerAccessKey, string aws4SignerSecretKey, int timeout)
             : base(server, port, ssl, allowSelfSignedServerCert, basicAuthUsername, basicAuthPassword, useAWS4Signer,
-                aws4SignerRegion, aws4SignerAccessKey, aws4SignerSecretKey)
+                aws4SignerRegion, aws4SignerAccessKey, aws4SignerSecretKey, timeout)
         {
             if (Ssl && AllowSelfSignedServerCert)
             {
@@ -140,7 +142,7 @@ namespace log4stash
             var webRequest = WebRequest.Create(url);
             webRequest.ContentType = "text/plain";
             webRequest.Method = "POST";
-            webRequest.Timeout = 10000;
+            webRequest.Timeout = Timeout;
             SetHeaders((HttpWebRequest)webRequest, url, requestString);
             return new RequestDetails(webRequest, requestString);
         }

--- a/src/log4stash/ElasticClient/ElasticClient.cs
+++ b/src/log4stash/ElasticClient/ElasticClient.cs
@@ -238,10 +238,9 @@ namespace log4stash
                 foreach (var header in headers.Keys)
                 {
                     if (header.Equals("host", StringComparison.OrdinalIgnoreCase))
-                    {
-                        //webRequest.Host = headers[header];
-                    }
-                    else if (header.Equals("content-length", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    if (header.Equals("content-length", StringComparison.OrdinalIgnoreCase))
                         webRequest.ContentLength = long.Parse(headers[header]);
                     else if (header.Equals("content-type", StringComparison.OrdinalIgnoreCase))
                         webRequest.ContentType = headers[header];

--- a/src/log4stash/ElasticSearchAppender.cs
+++ b/src/log4stash/ElasticSearchAppender.cs
@@ -39,6 +39,7 @@ namespace log4stash
         public string AWS4SignerRegion { get; set; }
         public string AWS4SignerAccessKey { get; set; }
         public string AWS4SignerSecretKey { get; set; }
+        public int ElasticSearchTimeout { get; set; }
         public TemplateInfo Template { get; set; }
         public ElasticAppenderFilters ElasticFilters { get; set; }
         public ILogEventFactory LogEventFactory { get; set; }
@@ -78,7 +79,7 @@ namespace log4stash
         public override void ActivateOptions()
         {
             _client = new WebElasticClient(Server, Port, Ssl, AllowSelfSignedServerCert, BasicAuthUsername, BasicAuthPassword, UseAWS4Signer,
-                AWS4SignerRegion, AWS4SignerAccessKey, AWS4SignerSecretKey);
+                AWS4SignerRegion, AWS4SignerAccessKey, AWS4SignerSecretKey, ElasticSearchTimeout);
 
             LogEventFactory.Configure(this);
 

--- a/src/log4stash/ElasticSearchAppender.cs
+++ b/src/log4stash/ElasticSearchAppender.cs
@@ -35,6 +35,10 @@ namespace log4stash
         public string BasicAuthPassword { get; set; }
         public bool IndexAsync { get; set; }
         public int MaxAsyncConnections { get; set; }
+        public bool UseAWS4Signer { get; set; }
+        public string AWS4SignerRegion { get; set; }
+        public string AWS4SignerAccessKey { get; set; }
+        public string AWS4SignerSecretKey { get; set; }
         public TemplateInfo Template { get; set; }
         public ElasticAppenderFilters ElasticFilters { get; set; }
         public ILogEventFactory LogEventFactory { get; set; }
@@ -73,7 +77,8 @@ namespace log4stash
 
         public override void ActivateOptions()
         {
-            _client = new WebElasticClient(Server, Port, Ssl, AllowSelfSignedServerCert, BasicAuthUsername, BasicAuthPassword);
+            _client = new WebElasticClient(Server, Port, Ssl, AllowSelfSignedServerCert, BasicAuthUsername, BasicAuthPassword, UseAWS4Signer,
+                AWS4SignerRegion, AWS4SignerAccessKey, AWS4SignerSecretKey);
 
             LogEventFactory.Configure(this);
 

--- a/src/log4stash/log4stash.csproj
+++ b/src/log4stash/log4stash.csproj
@@ -54,6 +54,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AWS4SignerForAuthorizationHeader.cs" />
+    <Compile Include="AWS4SignerBase.cs" />
     <Compile Include="ElasticClient\CompositeElasticClient.cs" />
     <Compile Include="ElasticClient\IElasticsearchClient.cs" />
     <Compile Include="ElasticClient\InnerBulkOperation.cs" />
@@ -86,6 +88,7 @@
     <None Include="log4stash.props" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <PropertyGroup>


### PR DESCRIPTION
The need is to use logstash together with Amazon ElasticSearch Service.
To provide this support, I added the following parameters in the appender configuration:

<UseAWS4Signer>true/false</UseAWS4Signer>
<AWS4SignerRegion>aws es region</AWS4SignerRegion>
<AWS4SignerAccessKey>aws user access key</AWS4SignerAccessKey>
<AWS4SignerSecretKey>aws user secret key</AWS4SignerSecretKey>

The idea is to calculate the correct signature for requests
according to the rules can be found here: http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html

I tried to keep changes the simplest possible, but I confess I do not like the way the code that generates the header
was after the changes. It seems that it could be more polymorphic, but this would change a little too much of the code structure.
