### PR TITLE
Changed the way to determine if response contains an error

### DIFF
--- a/src/log4stash/ElasticClient/PartialElasticResponse.cs
+++ b/src/log4stash/ElasticClient/PartialElasticResponse.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace log4stash
+{
+    internal sealed class PartialElasticResponse
+    {
+        [JsonProperty("errors")]
+        public bool Errors { get; set; }
+    }
+}

--- a/src/log4stash/log4stash.csproj
+++ b/src/log4stash/log4stash.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Configuration\ServerDataCollection.cs" />
     <Compile Include="ElasticClient\IElasticsearchClient.cs" />
     <Compile Include="ElasticClient\InnerBulkOperation.cs" />
+    <Compile Include="ElasticClient\PartialElasticResponse.cs" />
     <Compile Include="Filters\ConvertFilter.cs" />
     <Compile Include="Filters\XmlFilter.cs" />
     <Compile Include="LogEventFactory\BasicLogEventFactory.cs" />


### PR DESCRIPTION
Sometimes ELasticSearch returns an http response with OK code, but with error in body.
These cases were not noticed by log4stash, user was not notified.