### PR TITLE
Updated the nuspec to support .net core 2.0

### DIFF
--- a/log4stash.nuspec
+++ b/log4stash.nuspec
@@ -36,9 +36,19 @@
     <copyright>Copyright 2017</copyright>
     <tags>log logging exception elasticsearch log4net appender logstash filters</tags>
     <dependencies>
-      <group>
-        <dependency id="log4net" version="2.0.8.0" />
-      </group>
+		<group targetFramework=".NETFramework3.5">
+			<dependency id="log4net" version="2.0.8.0" />
+		</group>
+		<group targetFramework=".NETFramework4.0">
+			<dependency id="log4net" version="2.0.8.0" />
+		</group>
+		<group targetFramework=".NETFramework4.5">
+			<dependency id="log4net" version="2.0.8.0" />
+		</group>
+		<group targetFramework=".NETStandard2.0">
+			<dependency id="log4net" version="2.0.8.0" />
+			<dependency id="System.Security.Permissions" version="4.4.0" />
+		</group>
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Adeed dependency for System.Security.Permissions so the appender would run in a .net core 2.0 project.
The package supports .net core 2.0 and above with this.
I was able to log a document to elastic after the change.
When installed in a .net core 2.0 project it would show a warning, but it works.