### PR TITLE
update content-type in aws signing code to application/json for ES 6.0

### DIFF
--- a/src/log4stash/Authentication/AwsAuthenticationMethod.cs
+++ b/src/log4stash/Authentication/AwsAuthenticationMethod.cs
@@ -22,7 +22,7 @@ namespace log4stash.Authentication
             var headers = new Dictionary<string, string>
                     {
                         {Aws4SignerBase.X_Amz_Content_SHA256, contentHashString},
-                        {"content-type", "text/plain"}
+                        {"content-type", "application/json"}
                     };
 
             var signer = new Aws4SignerForAuthorizationHeader


### PR DESCRIPTION
Found an issue while trying to use this against an AWS ElasticSearch instance. The AWS signing code overwrites the content type so requests continue to receive error 406 