### PR TITLE
Feature/allow utc smart formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ You can also set any public property in the appender/filter which didn't appear 
 	<Port>9200</Port>
 	<!-- optional: in case elasticsearch is located behind a reverse proxy the URL is like http://Server:Port/Path, default = empty string -->
 	<Path>/es5</Path>
+	<!-- The time zone for the formatter is based on the character before the index. '+' = local time, '~' = utc time -->
 	<IndexName>log_test_%{+yyyy-MM-dd}</IndexName>
 	<!-- type support was removed in ElasticSearch 7, so if not defined in configuration there won't be a type in the request -->
 	<IndexType>LogEvent</IndexType>

--- a/src/log4stash.UnitTests/LogEventSmartFormatterTests.cs
+++ b/src/log4stash.UnitTests/LogEventSmartFormatterTests.cs
@@ -25,7 +25,7 @@ namespace log4stash.UnitTests
             result.Should().Be(expected);
         }
 
-        private const string DateFormat = "HH";
+        private const string DateFormat = "HH:mm";
 
         private static readonly string UtcHour = DateTime.UtcNow.ToString(DateFormat, CultureInfo.InvariantCulture);
         private static readonly string LocalHour = DateTime.Now.ToString(DateFormat, CultureInfo.InvariantCulture);

--- a/src/log4stash.UnitTests/LogEventSmartFormatterTests.cs
+++ b/src/log4stash.UnitTests/LogEventSmartFormatterTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using FluentAssertions;
+using log4stash.SmartFormatters;
+using NUnit.Framework;
+
+namespace log4stash.UnitTests
+{
+    [TestFixture]
+    public class LogEventSmartFormatterTests
+    {
+        [Test]
+        [TestCaseSource(nameof(TimeZoneCases))]
+        public void FORMATTER_SHOULD_USE_CORRECT_DATE_TIMEZONE_ACCORDING_TO_LEADING_SYMBOL(string format,
+            string expected)
+        {
+            //Arrange
+            var formatter = new LogEventSmartFormatter(format);
+            //Act
+            var result = formatter.Format();
+
+            //Assert
+            result.Should().Be(expected);
+        }
+
+        private const string DateFormat = "HH";
+
+        private static readonly string UtcHour = DateTime.UtcNow.ToString(DateFormat, CultureInfo.InvariantCulture);
+        private static readonly string LocalHour = DateTime.Now.ToString(DateFormat, CultureInfo.InvariantCulture);
+
+        private static readonly TestCaseData[] TimeZoneCases =
+        {
+            new TestCaseData($"%{{+{DateFormat}}}", LocalHour),
+            new TestCaseData($"%{{~{DateFormat}}}", UtcHour),
+        };
+    }
+}

--- a/src/log4stash/SmartFormatters/LogEventSmartFormatter.cs
+++ b/src/log4stash/SmartFormatters/LogEventSmartFormatter.cs
@@ -33,6 +33,12 @@ namespace log4stash.SmartFormatters
                 replacementString = DateTime.Now.ToString(innerMatch.Substring(1), CultureInfo.InvariantCulture);
                 return true;
             }
+            //the "~" is an arbitrary choice, could be any character that means utc
+            if (innerMatch.StartsWith("~"))
+            {
+                replacementString = DateTime.UtcNow.ToString(innerMatch.Substring(1), CultureInfo.InvariantCulture);
+                return true;
+            }
 
             object token;
             if (logEvent.TryGetValue(innerMatch, out token))

--- a/src/log4stash/SmartFormatters/LogEventSmartFormatter.cs
+++ b/src/log4stash/SmartFormatters/LogEventSmartFormatter.cs
@@ -13,6 +13,8 @@ namespace log4stash.SmartFormatters
     /// </summary>
     public class LogEventSmartFormatter : SmartFormatter
     {
+        private const string LocalDateSymbol = "+";
+        private const string UtcDateSymbol = "~";
         private static readonly Regex InnerRegex = new Regex(@"%\{([^\}]+)\}", RegexOptions.Compiled);
         
 
@@ -28,13 +30,13 @@ namespace log4stash.SmartFormatters
             string innerMatch = match.Groups[1].Value;
 
             // "+" means dateTime format
-            if (innerMatch.StartsWith("+"))
+            if (innerMatch.StartsWith(LocalDateSymbol))
             {
                 replacementString = DateTime.Now.ToString(innerMatch.Substring(1), CultureInfo.InvariantCulture);
                 return true;
             }
             //the "~" is an arbitrary choice, could be any character that means utc
-            if (innerMatch.StartsWith("~"))
+            if (innerMatch.StartsWith(UtcDateSymbol))
             {
                 replacementString = DateTime.UtcNow.ToString(innerMatch.Substring(1), CultureInfo.InvariantCulture);
                 return true;


### PR DESCRIPTION
Added an option to user the '~' character before a date format to use UTC timezone instead of local timezone.
This is a solution for issue #83 